### PR TITLE
Bot launch fix

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,7 +2,6 @@ en:
   site_settings:
       discord_bot_enabled: "Enable the Discourse Discord bot plugin"
       discord_bot_token: "Enter your bot TOKEN from Discord here"
-      discord_bot_client_id: "Enter your Discord app CLIENT ID"
       discord_bot_admin_channel_id: "The id of your admin text channel on Discord"
       discord_bot_admin_role_id: "The id of your admin role on Discord for which commands are permitted"
       discord_bot_rate_limit_delay: "The delay in seconds between sending commands to Discord so we don't annihilate rate limits"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,7 +1,8 @@
 en:
   site_settings:
       discord_bot_enabled: "Enable the Discourse Discord bot plugin"
-      discord_bot_token: "Enter your bot token from Discord here"
+      discord_bot_token: "Enter your bot TOKEN from Discord here"
+      discord_bot_client_id: "Enter your Discord app CLIENT ID"
       discord_bot_admin_channel_id: "The id of your admin text channel on Discord"
       discord_bot_admin_role_id: "The id of your admin role on Discord for which commands are permitted"
       discord_bot_rate_limit_delay: "The delay in seconds between sending commands to Discord so we don't annihilate rate limits"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,9 @@ plugins:
   discord_bot_token:
     default: ''
     client: false
+  discord_bot_client_id:
+    default: ''
+    client: false
   discord_bot_admin_channel_id:
     default: ''
     client: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,9 +5,6 @@ plugins:
   discord_bot_token:
     default: ''
     client: false
-  discord_bot_client_id:
-    default: ''
-    client: false
   discord_bot_admin_channel_id:
     default: ''
     client: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,11 +29,12 @@ register_asset 'stylesheets/common/discord.scss'
 after_initialize do
 
   def run_bot
-    bot = Discordrb::Commands::CommandBot.new token: SiteSetting.discord_bot_token, client_id: SiteSetting.discord_bot_client_id, prefix: '!'
+    bot = Discordrb::Commands::CommandBot.new token: SiteSetting.discord_bot_token, prefix: '!'
     bot.bucket :admin_tasks, limit: 3, time_span: 60, delay: 10
 
     bot.ready do |event|
       puts "Logged in as #{bot.profile.username} (ID:#{bot.profile.id}) | #{bot.servers.size} servers"
+      bot.send_message(SiteSetting.discord_bot_admin_channel_id, "The Discourse admin bot has started his shift!")
     end
 
     # '!disckick' - a command to kick members beneath a certain trust level on Discourse
@@ -277,8 +278,6 @@ after_initialize do
     bot.message(with_text: 'Ping!' ) do |event|
       event.respond 'Pong!'
     end
-
-    bot.send_message(SiteSetting.discord_bot_admin_channel_id, "The Discourse admin bot has started his shift!")
 
     bot.run
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,7 +29,7 @@ register_asset 'stylesheets/common/discord.scss'
 after_initialize do
 
   def run_bot
-    bot = Discordrb::Commands::CommandBot.new token: SiteSetting.discord_bot_token, prefix: '!'
+    bot = Discordrb::Commands::CommandBot.new token: SiteSetting.discord_bot_token, client_id: SiteSetting.discord_bot_client_id, prefix: '!'
     bot.bucket :admin_tasks, limit: 3, time_span: 60, delay: 10
 
     bot.ready do |event|


### PR DESCRIPTION
sending a message before the bot runs for the first time will cause a bad request, so move this into the bot.ready event.