### PR TITLE
FEATURE: add support for Discord attachments and option to mask bot messages

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,6 +10,7 @@ en:
     discord_bot_message_copy_topic_size_limit: "Message history copy: number of Discord messages per Discourse Topic"
     discord_bot_message_copy_default_category: "If no Category specified and Channel name doesn't match a Discourse Category use this Category to paste Topics"
     discord_bot_message_copy_convert_discord_mentions_to_usernames: "Convert mentions within Discord messages to Discourse or Discord usernames"
+    discord_bot_message_copy_ignore_bot_messages: "Ignore messages by bot and do not copy over"
     discord_bot_post_announcement_categories: "Announce new Posts in here within the announcements channel"
     discord_bot_topic_announcement_categories: "Announce new Topics in here within the announcements channel"
     discord_bot_rate_limit_delay: "The delay in seconds between sending commands to Discord so we don't annihilate rate limits"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,9 @@ plugins:
   discord_bot_message_copy_convert_discord_mentions_to_usernames:
     client: false
     default: true
+  discord_bot_message_copy_ignore_bot_messages:
+    client: false
+    default: true
   discord_bot_unknown_user_proxy_account:
     client: false
     type: username

--- a/lib/bot_commands.rb
+++ b/lib/bot_commands.rb
@@ -78,10 +78,12 @@ module ::DiscordBot::BotCommands
 
         total_copied_messages = 0
         current_topic_id = nil
+        bot_user_id = Base64.decode64(bot.token.split(" ")[1].split(".")[0])
 
         past_messages.reverse.in_groups_of(SiteSetting.discord_bot_message_copy_topic_size_limit.to_i).each_with_index do |message_batch, index|
           message_batch.each_with_index do |pm, topic_index|
             next if pm.nil?
+            next if SiteSetting.discord_bot_message_copy_ignore_bot_messages && pm.author.id == bot_user_id
             raw = pm.to_s
 
             if SiteSetting.discord_bot_message_copy_convert_discord_mentions_to_usernames

--- a/lib/bot_commands.rb
+++ b/lib/bot_commands.rb
@@ -78,7 +78,7 @@ module ::DiscordBot::BotCommands
 
         total_copied_messages = 0
         current_topic_id = nil
-        bot_user_id = Base64.decode64(bot.token.split(" ")[1].split(".")[0])
+        bot_user_id = Base64.decode64(bot.token.split(" ")[1].split(".")[0]).to_i
 
         past_messages.reverse.in_groups_of(SiteSetting.discord_bot_message_copy_topic_size_limit.to_i).each_with_index do |message_batch, index|
           message_batch.each_with_index do |pm, topic_index|

--- a/lib/bot_commands.rb
+++ b/lib/bot_commands.rb
@@ -98,7 +98,7 @@ module ::DiscordBot::BotCommands
             end
 
             pm.attachments.each do |attachment|
-              raw = raw + "\n\n" + attachment.proxy_url
+              raw = raw + "\n\n" + attachment.url
             end
 
             associated_user = UserAssociatedAccount.find_by(provider_uid: pm.author.id)

--- a/lib/bot_commands.rb
+++ b/lib/bot_commands.rb
@@ -98,7 +98,11 @@ module ::DiscordBot::BotCommands
             end
 
             pm.attachments.each do |attachment|
-              raw = raw + "\n\n" + attachment.url
+              if attachment.content_type.include?("image")
+                raw = raw + "\n\n" + attachment.url
+              else
+                raw = raw + "\n\n<a href='#{attachment.url}'>#{attachment.filename}</a>"
+              end
             end
 
             associated_user = UserAssociatedAccount.find_by(provider_uid: pm.author.id)

--- a/lib/bot_commands.rb
+++ b/lib/bot_commands.rb
@@ -97,6 +97,10 @@ module ::DiscordBot::BotCommands
               end
             end
 
+            pm.attachments.each do |attachment|
+              raw = raw + "\n\n" + attachment.proxy_url
+            end
+
             associated_user = UserAssociatedAccount.find_by(provider_uid: pm.author.id)
             unless associated_user.nil?
               posting_user = User.find_by(id: associated_user.user_id)

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-discord-bot
 # about: Integrate Discord Bots with Discourse
-# version: 0.3.8
+# version: 0.3.9
 # authors: Robert Barrow
 # url: https://github.com/merefield/discourse-discord-bot
 


### PR DESCRIPTION
* extracts the (Discord cdn url) of attachments and posts the URL as part of the copied message
* adds setting `discord_bot_message_copy_ignore_bot_messages`, default ON, which controls whether bot authored messages are included in the copy.